### PR TITLE
Fixed issue with z tilting being applied to tilemap draws as of April 2024 release

### DIFF
--- a/objects/obj_render/Create_0.gml
+++ b/objects/obj_render/Create_0.gml
@@ -23,9 +23,13 @@ enum RenderState{
 	reset,
 	size
 }
-renderstate=RenderState.set; // default  
-layer_script_end(layer_get_id("blyr"),render_layer_master) // start zbuffering after background has drawn and cleared the screen!
-layer_script_begin(layer_get_id("ilyr_controllers"),render_layer_master) // end zbuffering before controllers run
+renderstate=RenderState.set; // default
+
+layer_script_end(layer_get_id("blyr"),render_layer_tilemap) // start zbuffering after background has drawn and cleared the screen!
+layer_script_end(layer_get_id("tiles_mid"),render_layer_objects) // enable corner IDs for tilting sprites
+layer_script_end(layer_get_id("alyr_terrain_mid"),render_layer_tilemap) // disable corner IDs when drawing more tile layers
+layer_script_end(layer_get_id("tiles_high"), render_layer_objects) // enable corner IDs again
+layer_script_begin(layer_get_id("ilyr_controllers"),render_layer_reset) // end zbuffering before controllers run
 
 /// === Tilt Asset Layer Sprites by modifying the alpha channel === //
 tilt=true;

--- a/scripts/render_layer_master/render_layer_master.gml
+++ b/scripts/render_layer_master/render_layer_master.gml
@@ -1,59 +1,135 @@
-if event_number!=0 exit; // runs only in GM native draw event: where tiles, backgrounds etc render - or custom code in objects!
-with(obj_render){
-	switch(renderstate){
-		case RenderState.set:
-			gpu_set_ztestenable(true);			// ztest what we draw from here on out
-			gpu_set_zwriteenable(true);			// fill in the zbuffer with the info of the things being drawn - not just testing
-			//gpu_set_alphatestenable(true);	// Alpha testing - handled in the shader, required if we dont use a custom shader!
-			//gpu_set_alphatestref(1);
-			shader_set(shd_ztilt);
-			shader_enable_corner_id(true);		// this is the magic ingredient! it allows us to distinguish which vertex is which in a shader!
-			shader_set_uniform_f(shader_get_uniform(shd_ztilt,"atest"),alpha_testing); // uniform is not required for shader to function! merely for illustration purposes!
-			renderstate=RenderState.reset;
-			break;
+function render_layer_master() {
+	if event_number!=0 exit; // runs only in GM native draw event: where tiles, backgrounds etc render - or custom code in objects!
+	with(obj_render){
+		switch(renderstate){
+			case RenderState.set:
+				gpu_set_ztestenable(true);			// ztest what we draw from here on out
+				gpu_set_zwriteenable(true);			// fill in the zbuffer with the info of the things being drawn - not just testing
+				//gpu_set_alphatestenable(true);	// Alpha testing - handled in the shader, required if we dont use a custom shader!
+				//gpu_set_alphatestref(1);
+				shader_set(shd_ztilt);
+				shader_enable_corner_id(true);		// this is the magic ingredient! it allows us to distinguish which vertex is which in a shader!
+				shader_set_uniform_f(shader_get_uniform(shd_ztilt,"atest"),alpha_testing); // uniform is not required for shader to function! merely for illustration purposes!
+				renderstate=RenderState.reset;
+				break;
 		
-		case RenderState.reset:
-			shader_reset();
-			shader_enable_corner_id(false);
-			gpu_set_ztestenable(false);
-			gpu_set_zwriteenable(false);
-			//gpu_set_alphatestenable(false); 
-			renderstate=RenderState.set;
+			case RenderState.reset:
+				shader_reset();
+				shader_enable_corner_id(false);
+				gpu_set_ztestenable(false);
+				gpu_set_zwriteenable(false);
+				//gpu_set_alphatestenable(false); 
+				renderstate=RenderState.set;
 			
-			// ==== BONUS: Add Character Silhouette === //
-			if silhouette{
-			/*
-				The following code adds a silhouette effect to the player. It does so by drawing the character again, at the same depth value as the player!
-				This depth correction is achieved by setting a shader uniform with the desired depth value, and overriding the positiion in the vertexshader.
-				The setting of the uniform will incur one batch break per object which is far from optimal. There are much better solutions than doing this 
-				once per object, however I feel it is sufficient for this neat bonus addition.
+				// ==== BONUS: Add Character Silhouette === //
+				if silhouette{
+				/*
+					The following code adds a silhouette effect to the player. It does so by drawing the character again, at the same depth value as the player!
+					This depth correction is achieved by setting a shader uniform with the desired depth value, and overriding the positiion in the vertexshader.
+					The setting of the uniform will incur one batch break per object which is far from optimal. There are much better solutions than doing this 
+					once per object, however I feel it is sufficient for this neat bonus addition.
 				
-				If you wanted the characters silhouette to not be affected by, say the grass bushes, then you would need to draw the bushes AFTER the silhouette
-				and the character, so that these positions on the z-buffer are not yet flagged as occluded! Hence we dont want them to hang in the air this 
-				would require further z-trickery, such as eg. matrix transforms to get the grass back down to be infront of the characters feet, and not in the sky
-				where it draws over the characters head...!
+					If you wanted the characters silhouette to not be affected by, say the grass bushes, then you would need to draw the bushes AFTER the silhouette
+					and the character, so that these positions on the z-buffer are not yet flagged as occluded! Hence we dont want them to hang in the air this 
+					would require further z-trickery, such as eg. matrix transforms to get the grass back down to be infront of the characters feet, and not in the sky
+					where it draws over the characters head...!
 				
-			*/
-			// set properties
-					gpu_set_zfunc(cmpfunc_greater);		// check for occluded pixel instead of non-occluded (cmpfunc_lessequal);
-					gpu_set_ztestenable(true);			// a silhouette needs to depth test
-					gpu_set_zwriteenable(false);		// but it does NOT need to write onto the z-buffer, this also means we need no alpha testing in the fragment!
-					shader_set(shd_ztilt_silhouette);
-					shader_enable_corner_id(true);
+				*/
+				// set properties
+						gpu_set_zfunc(cmpfunc_greater);		// check for occluded pixel instead of non-occluded (cmpfunc_lessequal);
+						gpu_set_ztestenable(true);			// a silhouette needs to depth test
+						gpu_set_zwriteenable(false);		// but it does NOT need to write onto the z-buffer, this also means we need no alpha testing in the fragment!
+						shader_set(shd_ztilt_silhouette);
+						shader_enable_corner_id(true);
 			
-					// draw player
-					with(obj_player){
-						shader_set_uniform_f(shader_get_uniform(shd_ztilt_silhouette,"in_Zcorrection"),depth); // tiny depth offset so the silhouette of the player does not apply to itself!
-						event_perform(ev_draw,0);
-					}
+						// draw player
+						with(obj_player){
+							shader_set_uniform_f(shader_get_uniform(shd_ztilt_silhouette,"in_Zcorrection"),depth); // tiny depth offset so the silhouette of the player does not apply to itself!
+							event_perform(ev_draw,0);
+						}
 			
-					// restore defaults!
-					shader_reset();
-					shader_enable_corner_id(false);
-					gpu_set_ztestenable(false);
-					gpu_set_zfunc(cmpfunc_lessequal); // default!
-			}
-			// ================================================= //
-			break;
+						// restore defaults!
+						shader_reset();
+						shader_enable_corner_id(false);
+						gpu_set_ztestenable(false);
+						gpu_set_zfunc(cmpfunc_lessequal); // default!
+				}
+				// ================================================= //
+				break;
+		}
+	}
+
+
+}
+
+function render_layer_tilemap()
+{
+	if event_number != 0 exit;
+	with(obj_render)
+	{
+		gpu_set_ztestenable(true);			// ztest what we draw from here on out
+		gpu_set_zwriteenable(true);			// fill in the zbuffer with the info of the things being drawn - not just testing
+		shader_set(shd_ztilt);
+		shader_enable_corner_id(false);		// this is the magic ingredient! it allows us to distinguish which vertex is which in a shader!
+		shader_set_uniform_f(shader_get_uniform(shd_ztilt,"atest"),alpha_testing); // uniform is not required for shader to function! merely for illustration purposes!
+	}
+}
+
+function render_layer_objects()
+{
+	if event_number != 0 exit;
+	with(obj_render)
+	{
+		gpu_set_ztestenable(true);			// ztest what we draw from here on out
+		gpu_set_zwriteenable(true);			// fill in the zbuffer with the info of the things being drawn - not just testing
+		shader_set(shd_ztilt);
+		shader_enable_corner_id(true);		// this is the magic ingredient! it allows us to distinguish which vertex is which in a shader!
+		shader_set_uniform_f(shader_get_uniform(shd_ztilt,"atest"),alpha_testing); // uniform is not required for shader to function! merely for illustration purposes!
+	}
+}
+
+function render_layer_reset()
+{
+	if event_number != 0 exit;
+	with(obj_render)
+	{
+		shader_reset();
+		shader_enable_corner_id(false);
+		gpu_set_ztestenable(false);
+		gpu_set_zwriteenable(false);
+			
+		// ==== BONUS: Add Character Silhouette === //
+		if silhouette{
+		/*
+			The following code adds a silhouette effect to the player. It does so by drawing the character again, at the same depth value as the player!
+			This depth correction is achieved by setting a shader uniform with the desired depth value, and overriding the positiion in the vertexshader.
+			The setting of the uniform will incur one batch break per object which is far from optimal. There are much better solutions than doing this 
+			once per object, however I feel it is sufficient for this neat bonus addition.
+				
+			If you wanted the characters silhouette to not be affected by, say the grass bushes, then you would need to draw the bushes AFTER the silhouette
+			and the character, so that these positions on the z-buffer are not yet flagged as occluded! Hence we dont want them to hang in the air this 
+			would require further z-trickery, such as eg. matrix transforms to get the grass back down to be infront of the characters feet, and not in the sky
+			where it draws over the characters head...!
+				
+		*/
+		// set properties
+				gpu_set_zfunc(cmpfunc_greater);		// check for occluded pixel instead of non-occluded (cmpfunc_lessequal);
+				gpu_set_ztestenable(true);			// a silhouette needs to depth test
+				gpu_set_zwriteenable(false);		// but it does NOT need to write onto the z-buffer, this also means we need no alpha testing in the fragment!
+				shader_set(shd_ztilt_silhouette);
+				shader_enable_corner_id(true);
+			
+				// draw player
+				with(obj_player){
+					shader_set_uniform_f(shader_get_uniform(shd_ztilt_silhouette,"in_Zcorrection"),depth); // tiny depth offset so the silhouette of the player does not apply to itself!
+					event_perform(ev_draw,0);
+				}
+			
+				// restore defaults!
+				shader_reset();
+				shader_enable_corner_id(false);
+				gpu_set_ztestenable(false);
+				gpu_set_zfunc(cmpfunc_lessequal); // default!
+		}
 	}
 }


### PR DESCRIPTION
As of the April 2024 release of GameMaker tile map draws now apply vertex corner IDs. This change had caused issues in this project as the "shd_ztilt" shader uses the vertex corner ID to decide whether to apply a z offset to vertices on drawing. Previously since vertex corner IDs weren't applied when drawing tile maps the z offset was never applied to tile map vertices, however as of the April 2024 release a z offset is now applied to the top vertices if vertex corner IDs are enabled when drawing the tile map. In order to fix this I've added separate functions to the "render_layer_master" script for setting up rendering state for object and tile map layers, which are then applied to the correct layers in the "obj_render" Create event. This fixes visual issues that had appeared in the latest version of GameMaker.